### PR TITLE
Ensure python3 used for python3/

### DIFF
--- a/python3/setup.py
+++ b/python3/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import sys
 import re


### PR DESCRIPTION
  If you’re on macOS Big Sur (not sure about earlier releases) and haven’t installed a Python 3, `/usr/bin/python` is 2.7.16 and `/usr/bin/python3` is 3.8.2.

Of course, if you’re in a python3 virtual environment, `python` will mean `python3`, but should we rely on that? `python3/tests/testsuite.py` doesn’t!