### PR TITLE
omp/setup.py: open version_information in text mode

### DIFF
--- a/omp/setup.py
+++ b/omp/setup.py
@@ -25,7 +25,7 @@ class GNATCollOMP(SetupApp):
 
         # Set library version
         with open(os.path.join(config.source_dir, '..',
-                               'version_information'), 'rb') as fd:
+                               'version_information'), 'r') as fd:
             version = fd.read().strip()
         config.set_data('GNATCOLL_VERSION', version, sub='gprbuild')
 


### PR DESCRIPTION
Otherwise saving the config in setup_support.py will fail as a bytes
object is not encodeable as JSON. Luckily, version_information is text
anyways.

Specifically, this fixes the following error previously experienced with Python 3.8:

```
Libraries kind             static, static-pic, relocatable
Build mode                 PROD
Traceback (most recent call last):
  File "omp/setup.py", line 65, in <module>
    sys.exit(app.run())
  File "/build/source/setup_support.py", line 372, in run
    return args.command(args)
  File "/build/source/setup_support.py", line 265, in build
    config.save_data()
  File "/build/source/setup_support.py", line 175, in save_data
    json.dump(self.data, fd)
  File "/nix/store/6cfajs6lsy9b4wxp3jvyyl1g5x2pjmpr-python3-3.8.9/lib/python3.8/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/nix/store/6cfajs6lsy9b4wxp3jvyyl1g5x2pjmpr-python3-3.8.9/lib/python3.8/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/nix/store/6cfajs6lsy9b4wxp3jvyyl1g5x2pjmpr-python3-3.8.9/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/nix/store/6cfajs6lsy9b4wxp3jvyyl1g5x2pjmpr-python3-3.8.9/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/nix/store/6cfajs6lsy9b4wxp3jvyyl1g5x2pjmpr-python3-3.8.9/lib/python3.8/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/nix/store/6cfajs6lsy9b4wxp3jvyyl1g5x2pjmpr-python3-3.8.9/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```