### PR TITLE
gmp: give example project a separate object directory

### DIFF
--- a/gmp/examples/gmp_examples.gpr
+++ b/gmp/examples/gmp_examples.gpr
@@ -2,7 +2,7 @@ with "gnatcoll_gmp";
 
 project GMP_Examples is
    for Main use ("square_triangular_numbers.adb", "isprime.adb");
-   for Object_Dir use "../obj";
+   for Object_Dir use "obj";
    for Exec_Dir use ".";
 end GMP_Examples;
 


### PR DESCRIPTION
The example subdirectory is also installed system-wide as an example.
The user is expected to copy it, and does certainly not expect
gprbuild to write into the parent directory.